### PR TITLE
remove force crash when running on Forge

### DIFF
--- a/src/main/java/com/cleanroommc/scalar/ScalarLoadingPlugin.java
+++ b/src/main/java/com/cleanroommc/scalar/ScalarLoadingPlugin.java
@@ -17,9 +17,9 @@ public class ScalarLoadingPlugin implements IFMLLoadingPlugin {
             Class.forName("com.cleanroommc.loader.LanguageAdapterRegistry").getDeclaredMethod("registerLanguageAdapter", String.class, ILanguageAdapter.class).invoke(null, "scala", new ScalaLanguageAdapter());
         } catch (Throwable ex) {
             LOGGER.fatal("Not running on Cleanroom! Cause by {}", ex);
-            FMLCommonHandler.instance().exitJava(1, true);
         }
     }
+
     @Override
     public String[] getASMTransformerClass() {
         return new String[0];


### PR DESCRIPTION
## Summary
I think the title itself is already clear enough.

## testing
OpenComputer is a mod written in Scala. By testing with this mod, we can know if Scalar is somehow providing Scala lang(which, should not), and if there's compatibility issue related to Scala.
### modlist: 
![image](https://github.com/CleanroomMC/Scalar/assets/47418975/e37e14b6-cf5f-46fd-9a20-4218df92f39c)

### in a newly created world:
![image](https://github.com/CleanroomMC/Scalar/assets/47418975/76e0325a-1753-4531-a16b-ea1e6a44f2ea)
